### PR TITLE
Fast exec many bcp support

### DIFF
--- a/src/bcp_support.cpp
+++ b/src/bcp_support.cpp
@@ -1,0 +1,641 @@
+#include "pyodbc.h"
+#include "wrapper.h"
+#include "textenc.h"
+#include "connection.h"
+#include "bcp_support.h"
+#include <datetime.h>
+
+
+static bool get_driver_name(HDBC hdbc, char* buf, SQLSMALLINT buflen) {
+    SQLSMALLINT outlen = 0;
+    if (SQLGetInfo(hdbc, SQL_DRIVER_NAME, (SQLPOINTER)buf, buflen, &outlen) != SQL_SUCCESS)
+        return false;
+    buf[buflen-1] = '\0';
+    return true;
+}
+
+#ifdef _WIN32
+static FARPROC sym(HMODULE m, const char* n) {
+    FARPROC p = GetProcAddress(m, n);
+    if (!p) {
+        // Some builds decorate stdcall exports; can try common decorations as a fallback:
+        // e.g., "_bcp_initA@20"
+        // You can generate decorated names if needed, but "bcp_initA" works.
+    }
+    return p;
+}
+#else
+static void* sym(void* m, const char* n) {
+    return dlsym(m, n);
+}
+#endif
+
+template <class TMod, class TFn>
+static bool fill_sym(TMod mod, const char* a, const char* b, TFn& out) {
+#ifdef _WIN32
+    out = reinterpret_cast<TFn>(sym(mod, a));
+    if (!out && b) out = reinterpret_cast<TFn>(sym(mod, b));
+#else
+    out = reinterpret_cast<TFn>(sym(mod, a));
+    if (!out && b) out = reinterpret_cast<TFn>(sym(mod, b));
+#endif
+    return out != nullptr;
+}
+
+bool BcpLoadFromDriver(HDBC hdbc, BcpProcs& out) {
+    out = BcpProcs{}; // reset
+
+    char drv[256] = {0};
+    if (!get_driver_name(hdbc, drv, sizeof(drv)))
+        return false;
+
+#ifdef _WIN32
+    HMODULE mod = GetModuleHandleA(drv);    // Driver name is typically "msodbcsql17.dll" or "msodbcsql18.dll"
+    if (!mod) mod = LoadLibraryA(drv);      // Try again in case the driver name is not a full path
+    if (!mod) return false;
+
+    if (!fill_sym(mod, "bcp_initA",   "bcp_init",    out.bcp_initA))  return false;
+    if (!fill_sym(mod, "bcp_bind",    nullptr,       out.bcp_bind))   return false;
+    if (!fill_sym(mod, "bcp_collen",  nullptr,       out.bcp_collen)) return false;
+    if (!fill_sym(mod, "bcp_colptr",  nullptr,       out.bcp_colptr)) return false;
+    if (!fill_sym(mod, "bcp_sendrow", nullptr,       out.bcp_sendrow))return false;
+    fill_sym(mod,     "bcp_batch",    nullptr,       out.bcp_batch);  // optional
+    if (!fill_sym(mod,"bcp_done",     nullptr,       out.bcp_done))   return false;
+    fill_sym(mod,     "bcp_control",  nullptr,       out.bcp_control);// optional
+#else
+    // Linux/macOS: driver is typically "libmsodbcsql-18.X.so"
+    void* mod = dlopen(drv, RTLD_NOW|RTLD_LOCAL);
+    if (!mod) return false;
+
+    // On non-Windows the wide variants may be the canonical ones; you can also probe both.
+
+    if (!fill_sym(mod, "bcp_init",    "bcp_initA",   out.bcp_initA))  return false;
+    if (!fill_sym(mod, "bcp_bind",    nullptr,       out.bcp_bind))   return false;
+    if (!fill_sym(mod, "bcp_collen",  nullptr,       out.bcp_collen)) return false;
+    if (!fill_sym(mod, "bcp_colptr",  nullptr,       out.bcp_colptr)) return false;
+    if (!fill_sym(mod, "bcp_sendrow", nullptr,       out.bcp_sendrow))return false;
+    fill_sym(mod,     "bcp_batch",    nullptr,       out.bcp_batch);
+    if (!fill_sym(mod,"bcp_done",     nullptr,       out.bcp_done))   return false;
+    fill_sym(mod,     "bcp_control",  nullptr,       out.bcp_control);
+#endif
+
+    // Require the core set:
+    out.loaded = true;
+    return true;
+}
+
+/*=======================================================================================*/
+// Connection methods for BCP support
+/*=======================================================================================*/
+
+static const char* BCPCTX_CAPSULE = "pyodbc.BCPContext";
+
+// ---- tiny helpers ---------------------------------------
+static int is_space(char c) {
+    return c==' ' || c=='\t' || c=='\r' || c=='\n' || c=='\f';
+}
+static char up(char c) { return (c>='a' && c<='z') ? (char)(c - 'a' + 'A') : c; }
+
+// Skip whitespace and SQL-style comments
+static const char* skip_ws_and_comments(const char* p) {
+    for (;;) {
+        // whitespace
+        while (is_space(*p)) ++p;
+
+        // line comment: --
+        if (p[0]=='-' && p[1]=='-') {
+            p += 2;
+            while (*p && *p!='\n' && *p!='\r') ++p;
+            continue;
+        }
+        // block comment: /* ... */
+        if (p[0]=='/' && p[1]=='*') {
+            p += 2;
+            while (*p) {
+                if (p[0]=='*' && p[1]=='/') { p += 2; break; }
+                ++p;
+            }
+            continue;
+        }
+        return p;
+    }
+}
+
+// Case-insensitive match of a keyword; advances *pp on success
+static int match_kw(const char** pp, const char* kw) {
+    const char* p = *pp;
+    const char* k = kw;
+    while (*k) {
+        if (up(*p) != up(*k)) return 0;
+        ++p; ++k;
+    }
+    // ensure next char isn’t a letter/underscore continuing an identifier
+    char c = *p;
+    if ((c>='A' && c<='Z') || (c>='a' && c<='z') || c=='_') return 0;
+    *pp = p;
+    return 1;
+}
+
+// Parse bracketed identifier: starts at '[', supports ]] escape
+static int parse_bracket_ident(const char** pp, char* buf, int cap) {
+    const char* p = *pp; // p points to '['
+    ++p; // skip '['
+    int n = 0;
+    while (*p) {
+        if (*p == ']') {
+            if (p[1] == ']') { // escaped ] -> add one ]
+                if (n+1 >= cap) return -1;
+                buf[n++] = ']'; p += 2; continue;
+            } else {
+                ++p; // end
+                *pp = p;
+                if (n >= cap) return -1;
+                buf[n] = '\0';
+                return n;
+            }
+        }
+        if (n+1 >= cap) return -1;
+        buf[n++] = *p++;
+    }
+    return -1; // unterminated
+}
+
+// Parse quoted identifier: starts at '"', supports "" escape
+static int parse_quoted_ident(const char** pp, char* buf, int cap) {
+    const char* p = *pp; // points to '"'
+    ++p;
+    int n = 0;
+    while (*p) {
+        if (*p == '"') {
+            if (p[1] == '"') { // escaped "
+                if (n+1 >= cap) return -1;
+                buf[n++] = '"'; p += 2; continue;
+            } else {
+                ++p; // end
+                *pp = p;
+                if (n >= cap) return -1;
+                buf[n] = '\0';
+                return n;
+            }
+        }
+        if (n+1 >= cap) return -1;
+        buf[n++] = *p++;
+    }
+    return -1; // unterminated
+}
+
+// Parse bare identifier (letters, digits, _, $, #)
+static int is_ident_start(char c) {
+    return (c>='A'&&c<='Z') || (c>='a'&&c<='z') || c=='_' || c=='#' || c=='$';
+}
+
+// Check if the character is a valid part of the identifier 
+static int is_ident_part(char c) {
+    return is_ident_start(c) || (c>='0'&&c<='9');
+}
+
+// Parses a bare identifier from the input string into the buffer.
+static int parse_bare_ident(const char** pp, char* buf, int cap) {
+    const char* p = *pp;
+    if (!is_ident_start(*p)) return -1;
+    int n = 0;
+    while (is_ident_part(*p)) {
+        if (n+1 >= cap) return -1;
+        buf[n++] = *p++;
+    }
+    *pp = p;
+    if (n >= cap) return -1;
+    buf[n] = '\0';
+    return n;
+}
+
+// Parse a possibly quoted/bracketed identifier into buf
+static int parse_identifier(const char** pp, char* buf, int cap) {
+    const char* p = *pp;
+    if (*p == '[') {
+        int n = parse_bracket_ident(&p, buf, cap);
+        if (n < 0) return -1;
+        *pp = p; return n;
+    } else if (*p == '"') {
+        int n = parse_quoted_ident(&p, buf, cap);
+        if (n < 0) return -1;
+        *pp = p; return n;
+    } else {
+        int n = parse_bare_ident(&p, buf, cap);
+        if (n < 0) return -1;
+        *pp = p; return n;
+    }
+}
+
+// Skip a TOP ( ... ) [PERCENT] clause if present
+static void skip_top_clause(const char** pp) {
+    const char* p = *pp;
+    const char* save = p;
+    if (!match_kw(&p, "TOP")) return;   // not there
+    p = skip_ws_and_comments(p);
+    if (*p != '(') { *pp = save; return; }
+    // skip balanced parens depth 1
+    int depth = 0;
+    do {
+        if (*p == '(') ++depth;
+        else if (*p == ')') { --depth; if (depth==0) { ++p; break; } }
+        if (*p == '\0') { *pp = save; return; }
+        ++p;
+    } while (depth > 0);
+    p = skip_ws_and_comments(p);
+    // optional PERCENT
+    if (match_kw(&p, "PERCENT")) { /* ok */ }
+    *pp = p;
+}
+
+// Returns 1 on success and writes table name into out_name (NUL-terminated),
+// 0 on failure (out_name is left untouched).
+int parse_insert_table(const char* sql, char* out_name, int out_cap)
+{
+    const char* p = sql;
+    char part1[256];
+    char part2[256];
+
+    p = skip_ws_and_comments(p);
+
+    // INSERT
+    if (!match_kw(&p, "INSERT")) return 0;
+
+    // optional stuff between INSERT and INTO (e.g. TOP (...) PERCENT)
+    p = skip_ws_and_comments(p);
+    skip_top_clause(&p);
+    p = skip_ws_and_comments(p);
+
+    // INTO
+    if (!match_kw(&p, "INTO")) return 0;
+
+    // schema/table
+    p = skip_ws_and_comments(p);
+
+    // first identifier
+    if (parse_identifier(&p, part1, (int)sizeof(part1)) < 0) return 0;
+    p = skip_ws_and_comments(p);
+
+    // optional . second identifier
+    char* table = part1;
+    if (*p == '.') {
+        ++p;
+        p = skip_ws_and_comments(p);
+        if (parse_identifier(&p, part2, (int)sizeof(part2)) < 0) return 0;
+        table = part2; // last part is the table name
+    }
+
+    // (Optional) you can verify next non-space isn’t an obvious breaker,
+    // but we allow WITH(...), (col list), or DEFAULT VALUES — so no hard check here.
+
+    // Copy to output
+    // compute length
+    int n = 0; while (table[n] != '\0') ++n;
+    if (n <= 0 || out_cap <= 0 || n >= out_cap) return 0;
+    for (int i = 0; i < n; ++i) out_name[i] = table[i];
+    out_name[n] = '\0';
+    return 1;
+}
+
+// Dynamicaly loads BCP specific dependencies 
+bool ensure_bcp_loaded(Connection* self) {
+    if (self->bcp && self->bcp->loaded) return true;
+    if (!self->hdbc) return false;
+    if (!self->bcp) {
+        self->bcp = (BcpProcs*)PyMem_Calloc(1, sizeof(BcpProcs));
+        if (!self->bcp) { PyErr_NoMemory(); return false; }
+    }
+    return BcpLoadFromDriver(self->hdbc, *self->bcp);
+}
+
+// Frees the BCP context capsule 
+void BcpCtx_FreeCapsule(PyObject* cap) 
+{
+    BcpCtx* ctx = (BcpCtx*)PyCapsule_GetPointer(cap, BCPCTX_CAPSULE);
+    if (!ctx) return;
+    if (ctx->cols) {
+        for (int i = 0; i < ctx->ncols; ++i) {
+            if (ctx->cols[i].scratch) PyMem_Free(ctx->cols[i].scratch);
+        }
+        PyMem_Free(ctx->cols);
+    }
+    PyMem_Free(ctx);
+}
+
+// Update the driver’s pointer to this column’s data buffer
+int _bcp_set_colptr(BcpCtx* ctx, BcpCol* c)
+{
+    SQLRETURN rc;
+    Py_BEGIN_ALLOW_THREADS
+    rc = ctx->conn->bcp->bcp_colptr(ctx->conn->hdbc, (LPCBYTE)c->scratch, c->ordinal);
+    Py_END_ALLOW_THREADS
+    return (rc != FAIL);
+}
+
+// Free context buffer and clear pointer 
+void _bcp_ctx_free(BcpCtx* ctx) {
+    if (!ctx) return;
+    if (ctx->cols) {
+        for (int i = 0; i < ctx->ncols; ++i)
+            if (ctx->cols[i].scratch) PyMem_Free(ctx->cols[i].scratch);
+        PyMem_Free(ctx->cols);
+    }
+    PyMem_Free(ctx);
+}
+
+// Binds the buffer for the pased column 
+int _bcp_rebind_current(BcpCtx* ctx, BcpCol* c)
+{
+    // When we grow a varlen buffer, tell the driver the new max length.
+    const DBINT cbIndicator = 0;
+    const DBINT cbData  = c->isVarLen ? 0 : (DBINT)c->fixedSize;
+
+    SQLRETURN rc;
+    Py_BEGIN_ALLOW_THREADS
+    rc = ctx->conn->bcp->bcp_bind(ctx->conn->hdbc, (LPCBYTE)c->scratch, cbIndicator, cbData, NULL, 0, c->hostType, c->ordinal);
+    Py_END_ALLOW_THREADS
+
+    return (rc == SUCCEED);
+}
+
+// Binds buffers for all defined column types 
+int _bcp_bind_all(BcpCtx* ctx)
+{
+    for (int i = 0; i < ctx->ncols; ++i)
+    {
+        BcpCol* c = &ctx->cols[i];
+
+        // Ensure scratch exists and has at least 1 byte.
+        if (!c->scratch || c->scratchCap == 0) 
+        {
+            PyErr_SetString(PyExc_RuntimeError, "Internal error: BCP column scratch buffer not allocated.");
+            return 0;
+        }
+
+        // We bind a single, persistent host buffer per column.
+        // For fixed types it's the exact size; for varlen we set isVarlen = 0 and set length per row via bcp_collen.
+        const DBINT cbIndicator = 0;  // we keep the cbIndicator 0, this works for both static and var lengths 
+        const DBINT cbData = c->isVarLen ? 0 : (DBINT)c->fixedSize;
+
+        RETCODE rc = ctx->conn->bcp->bcp_bind(ctx->conn->hdbc,
+                              (LPCBYTE)c->scratch,  // driver reads from here on each sendrow
+                              cbIndicator,
+                              cbData,               // 0 for varlen; sizeof(T) for fixed
+                              /*pTerm*/ NULL,
+                              /*cbTerm*/ 0,
+                              /*eDataType*/ c->hostType,
+                              /*server col*/ c->ordinal);
+        if (rc != SUCCEED)
+            return 0;
+    }
+    return 1;
+
+}
+
+// Convert one Python cell into a column scratch buffer + set length via bcp_collen.
+// NULL -> SQL_NULL_DATA via bcp_collen for both fixed & varlen.
+int _bcp_fill_cell(BcpCtx* ctx, PyObject* cell, BcpCol* c)
+{
+    // NULL for this column on this row
+    if (cell == Py_None)
+    {
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, SQL_NULL_DATA, c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+
+    switch (c->hostType)
+    {
+    case SQLBIT: {
+        int truthy = PyObject_IsTrue(cell);
+        if (truthy < 0) return 0;       // error converting
+        unsigned char b = truthy ? 1 : 0;
+        memcpy(c->scratch, &b, 1);
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, 1, c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLINT2: {
+        long v = PyLong_AsLong(cell);
+        if (PyErr_Occurred()) return 0;
+        if (v < SHRT_MIN || v > SHRT_MAX) {
+            PyErr_SetString(PyExc_OverflowError, "SMALLINT out of range");
+            return 0;
+        }
+        short s = (short)v;
+        memcpy(c->scratch, &s, sizeof(short));
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(short), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLINT4:
+    {
+        // Accept ints; range-check
+        long long lv = PyLong_AsLongLong(cell);
+        if (PyErr_Occurred()) return 0;
+        DBINT v = (DBINT)lv;  // optional: check lv in [-2147483648, 2147483647]
+        memcpy(c->scratch, &v, sizeof(DBINT));
+
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(DBINT), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLINT8: {
+        long long v = PyLong_AsLongLong(cell);
+        if (PyErr_Occurred()) return 0;
+        memcpy(c->scratch, &v, sizeof(long long));
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(long long), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLFLT8:
+    {
+        // PyFloat_AsDouble also accepts ints (no need for PyFloat_Check here)
+        double d = PyFloat_AsDouble(cell);
+        if (PyErr_Occurred()) return 0;
+        memcpy(c->scratch, &d, sizeof(double));
+
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(double), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLFLT4: {
+        double dv = PyFloat_AsDouble(cell);
+        if (PyErr_Occurred()) return 0;
+        float fv = (float)dv;
+        memcpy(c->scratch, &fv, sizeof(float));
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(float), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLBINARY: {
+        const char* p = NULL;
+        Py_ssize_t n = 0;
+        PyObject* bytes_obj = NULL;
+
+        if (PyBytes_Check(cell)) {
+            bytes_obj = cell; Py_INCREF(bytes_obj);
+            p = PyBytes_AS_STRING(bytes_obj);
+            n = PyBytes_GET_SIZE(bytes_obj);
+        } else if (PyByteArray_Check(cell)) {
+            p = PyByteArray_AsString(cell);
+            n = PyByteArray_Size(cell);
+        } else {
+            PyErr_SetString(PyExc_TypeError, "Expected bytes/bytearray for VARBINARY/BINARY");
+            return 0;
+        }
+
+        DBINT bytes = (DBINT)n;
+        if (bytes > c->scratchCap) {
+            unsigned char* np = (unsigned char*)PyMem_Realloc(c->scratch, (size_t)bytes);
+            if (!np) { Py_XDECREF(bytes_obj); PyErr_NoMemory(); return 0; }
+            c->scratch = np; c->scratchCap = bytes;
+            if (!_bcp_rebind_current(ctx, c)) { Py_XDECREF(bytes_obj); return 0; }
+        }
+        if (bytes > 0) memcpy(c->scratch, p, (size_t)bytes);
+
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, bytes, c->ordinal);
+        Py_END_ALLOW_THREADS
+
+        Py_XDECREF(bytes_obj);
+        return (rc != FAIL);
+    }
+    case SQLUNIQUEID: {
+        unsigned char buf[16];
+        int ok = 0;
+        if (PyObject_HasAttrString(cell, "bytes_le")) {
+            PyObject* le = PyObject_GetAttrString(cell, "bytes_le");
+            if (le) {
+                if (PyBytes_Check(le) && PyBytes_GET_SIZE(le) == 16) {
+                    memcpy(buf, PyBytes_AS_STRING(le), 16);
+                    ok = 1;
+                }
+                Py_DECREF(le);
+            }
+        } else if (PyBytes_Check(cell) && PyBytes_GET_SIZE(cell) == 16) {
+            memcpy(buf, PyBytes_AS_STRING(cell), 16);
+            ok = 1;
+        }
+        if (!ok) {
+            PyErr_SetString(PyExc_TypeError, "GUID requires uuid.UUID or 16-byte bytes");
+            return 0;
+        }
+        memcpy(c->scratch, buf, 16);
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, 16, c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLCHARACTER:
+    {
+        const char* p = NULL;
+        Py_ssize_t n = 0;
+
+        if (PyUnicode_Check(cell)) {
+            p = PyUnicode_AsUTF8AndSize(cell, &n);   // <-- NO allocation
+            if (!p) return 0;
+        } else if (PyBytes_Check(cell)) {
+            p = PyBytes_AsString(cell);
+            if (!p) return 0;
+            n = PyBytes_GET_SIZE(cell);
+        } else if (PyByteArray_Check(cell)) {
+            p = PyByteArray_AsString(cell);
+            n = PyByteArray_Size(cell);
+        } else {
+            PyErr_SetString(PyExc_TypeError, "Expected str/bytes/bytearray for SQLCHARACTER");
+            return 0;
+        }
+
+        DBINT bytes = (DBINT)n;
+
+        if (bytes > c->scratchCap) {
+            unsigned char* np = (unsigned char*)PyMem_Realloc(c->scratch, (size_t)bytes);
+            if (!np) { PyErr_NoMemory(); return 0; }
+            c->scratch = np;
+            c->scratchCap = bytes;
+            if (!_bcp_rebind_current(ctx, c)) return 0;
+        }
+
+        if (bytes > 0)
+            memcpy(c->scratch, p, (size_t)bytes);
+
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, bytes, c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLTIMEN: {
+        PyObject* hh = PyObject_GetAttrString(cell, "hour");
+        PyObject* mm = PyObject_GetAttrString(cell, "minute");
+        PyObject* ss = PyObject_GetAttrString(cell, "second");
+        PyObject* us = PyObject_GetAttrString(cell, "microsecond");
+        if (!hh || !mm || !ss || !us) { Py_XDECREF(hh); Py_XDECREF(mm); Py_XDECREF(ss); Py_XDECREF(us);
+            PyErr_SetString(PyExc_TypeError, "TIME expects time/datetime"); return 0; }
+        TIME_STRUCT ts;
+        ts.hour   = (SQLUSMALLINT)PyLong_AsUnsignedLong(hh);
+        ts.minute = (SQLUSMALLINT)PyLong_AsUnsignedLong(mm);
+        ts.second = (SQLUSMALLINT)PyLong_AsUnsignedLong(ss);
+        Py_DECREF(hh); Py_DECREF(mm); Py_DECREF(ss);
+        if (PyErr_Occurred()) { Py_XDECREF(us); return 0; }
+
+        // Store fractional seconds in TIMESTAMP_STRUCT only; TIME_STRUCT has no fraction field.
+        // For TIME(p) precision, the driver will handle scale; to keep sub-second precision,
+        // prefer TIMESTAMP_STRUCT + SQLTIMESTAMP (or send text). For pure TIME, send "HH:MM:SS[.fff]" as text (Option A),
+        // or accept second-only here:
+        Py_XDECREF(us);
+
+        memcpy(c->scratch, &ts, sizeof(ts));
+        SQLRETURN rc; Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(TIME_STRUCT), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    default:
+        PyErr_SetString(PyExc_TypeError, "Unsupported host type in types[]");
+        return 0;
+    }
+}
+
+// helpers (top of file)
+void write_le(unsigned char* dst, unsigned long long v, int len) {
+    for (int i = 0; i < len; ++i) dst[i] = (unsigned char)((v >> (8*i)) & 0xFF);
+}
+
+// time ticks for TIME(7): 10^-7s since midnight
+unsigned long long time_to_ticks7(int hh, int mm, int ss, int micro) {
+    unsigned long long sec = (unsigned long long)hh*3600ULL + (unsigned long long)mm*60ULL + (unsigned long long)ss;
+    return sec * 10000000ULL + (unsigned long long)micro * 10ULL; // 1 micro = 10 * 1e-7
+}
+
+// days since 0001-01-01; 0001-01-01 = 0
+unsigned int days_since_0001_01_01(int y, int m, int d)
+{
+    // Howard Hinnant’s days-from-civil (adapted), shifted so 0001-01-01 = 0
+    y -= m <= 2;
+    const int era = (y >= 0 ? y : y-399) / 400;
+    const unsigned yoe = (unsigned)(y - era * 400);           // [0, 399]
+    const unsigned doy = (153*(m + (m > 2 ? -3 : 9)) + 2)/5 + d - 1; // [0, 365]
+    const unsigned doe = yoe*365 + yoe/4 - yoe/100 + doy;     // [0, 146096]
+    // days since 0000-03-01; convert to 0001-01-01 base:
+    // 0001-01-01 is 306 days after 0000-03-01.
+    const int days = era*146097 + (int)doe - 306;
+    return (unsigned int)days; // 0 for 0001-01-01
+}

--- a/src/bcp_support.h
+++ b/src/bcp_support.h
@@ -1,0 +1,299 @@
+#pragma once
+
+// --- Windows prerequisites so ODBC SAL/GUID types are present everywhere this header is used
+#ifdef _WIN32
+    #ifndef NOMINMAX
+    #define NOMINMAX
+    #endif
+    #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+    #endif
+    #include <windows.h>
+#else
+    #include <dlfcn.h>
+#endif
+
+#ifndef ODBCVER
+    #define ODBCVER 0x0380
+#endif
+
+// --- ODBC prerequisites
+#include <sql.h>
+#include <sqlext.h>
+
+// --- Provide minimal typedefs if the BCP headers are not included
+
+/* ---- DB-Library style constants used by the BCP API ---- */
+#ifndef DB_IN
+#define DB_IN 1
+#endif
+#ifndef DB_OUT
+#define DB_OUT 2
+#endif
+#ifndef SUCCEED
+#define SUCCEED 1
+#endif
+#ifndef FAIL
+#define FAIL 0
+#endif
+
+#ifndef DBINT
+// DBINT is 32-bit signed in the SQL Server driver
+typedef long DBINT;
+#endif
+
+#ifndef BYTE
+typedef unsigned char BYTE;
+#endif
+#ifndef LPCBYTE
+typedef const BYTE* LPCBYTE;
+#endif
+
+// ---- Minimal constants (used only if you can't include msodbcsql.h)
+#ifndef SQL_COPT_SS_BCP
+#define SQL_COPT_SS_BCP 1219       // ODBC Driver 17/18
+#endif
+#ifndef SQL_BCP_ON
+#define SQL_BCP_ON 1
+#endif
+#ifndef SQL_VARLEN_DATA
+#define SQL_VARLEN_DATA (-10)
+#endif
+
+// Supported Host types (fallbacks; prefer exporting real ones from the module)
+#ifndef SQLBIT                  // BIT (1 byte)
+#define SQLBIT  0x32
+#endif
+#ifndef SQLINT2                 // SMALLINT (2 bytes)
+#define SQLINT2 0x34
+#endif
+#ifndef SQLINT4                 // INTEGER (4 bytes)
+#define SQLINT4 0x38               
+#endif
+#ifndef SQLINT8                 // BIGINT (8 bytes)
+#define SQLINT8 0x7F
+#endif
+#ifndef SQLFLT8                 // FLOAT (8 bytes)
+#define SQLFLT8 0x3E               
+#endif
+#ifndef SQLFLT4                 // REAL / FLOAT(24) (4 bytes)
+#define SQLFLT4 0x3B
+#endif
+#ifndef SQLBINARY               // BINARY / VARBINARY host type
+#define SQLBINARY 0x2D
+#endif
+#ifndef SQLUNIQUEID             // UNIQUEIDENTIFIER host type
+#define SQLUNIQUEID 0x24
+#endif
+#ifndef SQLCHARACTER            // CHAR / VARCHAR / TEXT host type
+#define SQLCHARACTER 0x2F          
+#endif
+#ifndef SQLTIMEN                // host type for TIME_STRUCT
+#define SQLTIMEN 0x29
+#endif
+#ifndef SQLDATEN
+#define SQLDATEN 0x28
+#endif
+#ifndef SQLDATETIME2N
+#define SQLDATETIME2N 0x2A
+#endif
+#ifndef SQLDATETIMEOFFSETN
+#define SQLDATETIMEOFFSETN 0x2B
+#endif
+
+// Supported bcp_control options (guarded):
+#ifndef BCPBATCH
+#define BCPBATCH 4              // same as msodbcsql.h
+#endif
+#ifndef BCPMAXERRS
+#define BCPMAXERRS 1            // same as msodbcsql.h
+#endif
+#ifndef BCPKEEPNULLS
+#define BCPKEEPNULLS 5          // same as msodbcsql.h
+#endif
+#ifndef BCPHINTS
+#define BCPHINTS 10             // same as msodbcsql.h
+#endif
+
+struct Connection;  // forward declaration
+
+struct BcpProcs {
+    // ANSI signatures (the A-suffixed variants)
+    SQLRETURN (SQL_API *bcp_initA)(HDBC, const char*, const char*, const char*, int);
+    SQLRETURN (SQL_API *bcp_bind)  (HDBC, const BYTE*, int, DBINT, const BYTE*, int, int, int);
+    SQLRETURN (SQL_API *bcp_collen)(HDBC, DBINT, int);
+    SQLRETURN (SQL_API *bcp_colptr)(HDBC, const BYTE*, int);
+    SQLRETURN (SQL_API *bcp_sendrow)(HDBC);
+    DBINT     (SQL_API *bcp_batch)(HDBC);
+    DBINT     (SQL_API *bcp_done)(HDBC);
+    SQLRETURN (SQL_API *bcp_control)(HDBC, int, void*);
+    bool loaded = false;
+};
+
+// Load once per connection
+bool BcpLoadFromDriver(HDBC hdbc, BcpProcs& out);
+
+// Convenience macro to check availability
+#define HAS_BCP(p) ((p).loaded)
+
+static inline char lower_ascii(char c) { return (c >= 'A' && c <= 'Z') ? char(c + 32) : c; }
+
+typedef struct BcpCol_
+{
+    int ordinal;                // 1-based
+    int hostType;               // SQLINT4, SQLFLT8, SQLCHARACTER, SQLINT2, SQLINT8...
+    bool isVarLen;              // 1 if varlen (SQLCHARACTER), else 0
+    int ind;                    // byte length indicator for varlen; always 0 for fixed
+    size_t fixedSize;           // for fixed types
+    unsigned char* scratch;     // reusable per-column buffer
+    DBINT scratchCap;           // bytes
+} BcpCol;
+
+typedef struct BcpCtx_ {
+    Connection* conn;                   // borrowed from Connection
+    int         ncols;
+    BcpCol*     cols;
+    DBINT       total_committed;        // running total (optional)
+} BcpCtx;
+
+/**
+ * @brief Parses an SQL INSERT statement to extract the target table name.
+ *
+ * This function analyzes the provided SQL string and attempts to extract the name of the table
+ * into which data is being inserted. The extracted table name is written to the output buffer
+ * `out_name`, which has a capacity of `out_cap` bytes.
+ *
+ * @param sql       The SQL INSERT statement as a null-terminated string.
+ * @param out_name  Output buffer to receive the parsed table name.
+ * @param out_cap   Capacity of the output buffer in bytes.
+ * @return          Returns 1 on success, 0 on failure (e.g., if the table name cannot be parsed).
+ */
+int parse_insert_table(const char* sql, char* out_name, int out_cap);
+
+/**
+ * @brief Ensures that the Bulk Copy Program (BCP) library is loaded for the given connection.
+ *
+ * This function checks if the BCP library required for bulk data operations is loaded
+ * for the specified connection. If not, it attempts to load the library.
+ *
+ * @param self Pointer to the Connection object for which the BCP library should be loaded.
+ * @return true if the BCP library is successfully loaded or already loaded; false otherwise.
+ */
+bool ensure_bcp_loaded(Connection* self);
+
+/**
+ * @brief Frees resources associated with a BCP context capsule.
+ *
+ * This function is intended to be used as a destructor for Python capsule objects
+ * that encapsulate BCP (Bulk Copy Program) context data. It releases any memory or
+ * resources held by the capsule to prevent memory leaks.
+ *
+ * @param cap A pointer to the Python capsule object containing the BCP context.
+ */
+void BcpCtx_FreeCapsule(PyObject* cap);
+
+/**
+ * @brief Sets the column pointer for a BCP column in the given context.
+ *
+ * This function assigns the appropriate data pointer for the specified column
+ * within the Bulk Copy Program (BCP) context. It is typically used to prepare
+ * the column for data transfer operations.
+ *
+ * @param ctx Pointer to the BCP context structure.
+ * @param c Pointer to the BCP column structure whose data pointer is to be set.
+ * @return Returns 0 on success, or a non-zero error code on failure.
+ */
+int _bcp_set_colptr(BcpCtx* ctx, BcpCol* c);
+
+/**
+ * @brief Frees the resources associated with a BcpCtx context.
+ *
+ * This function releases all memory and resources allocated for the specified
+ * BcpCtx structure. After calling this function, the context pointer should not
+ * be used unless reinitialized.
+ *
+ * @param ctx Pointer to the BcpCtx context to be freed.
+ */
+void _bcp_ctx_free(BcpCtx* ctx);
+
+/**
+ * @brief Rebinds the current column in the BCP context.
+ *
+ * This function updates the binding of the specified column within the given BCP context.
+ * It is typically used when the column's data type or binding parameters have changed and
+ * need to be reapplied for bulk copy operations. Most common cause buffer size increase.
+ *
+ * @param ctx Pointer to the BCP context structure.
+ * @param c Pointer to the BCP column structure to be rebound.
+ * @return Returns 0 on success, or a non-zero error code on failure.
+ */
+int _bcp_rebind_current(BcpCtx* ctx, BcpCol* c);
+
+/**
+ * @brief Bind all column buffers for bulk copy (BCP) operations.
+ *
+ * Iterates over all columns in the given BCP context and binds each column’s
+ * scratch buffer using `bcp_bind()`. For fixed-size columns, the exact size is bound;
+ * for variable-length columns, the size is set per row via `bcp_collen()`.
+ *
+ * Fails if a column has no scratch buffer or if any bind call fails.
+ *
+ * @param ctx  Pointer to an initialized BCP context with valid column metadata.
+ * @return 1 on success, 0 on error (Python exception set).
+ */
+int _bcp_bind_all(BcpCtx* ctx);
+
+/**
+ * @brief Converts a Python value to a native buffer and binds it for BCP.
+ *
+ * Converts a single Python object to the column’s native type and writes it
+ * into the column’s scratch buffer. Then updates the column length using
+ * `bcp_collen()`. Handles `None` as SQL NULL and supports various SQL types
+ * (BIT, INT2/4/8, FLOAT4/8, BINARY, CHAR, UNIQUEID, TIMEN, etc.).
+ *
+ * @param ctx   Active BCP context.
+ * @param cell  Python object representing the cell value.
+ * @param c     Target column descriptor.
+ * @return 1 on success, 0 on error (Python exception set).
+ */
+int _bcp_fill_cell(BcpCtx* ctx, PyObject* cell, BcpCol* c);
+
+/**
+ * @brief Write an integer value to a buffer in little-endian order.
+ *
+ * Stores the lower @p len bytes of @p v into @p dst, least significant byte first.
+ *
+ * @param dst  Destination buffer.
+ * @param v    Integer value to write.
+ * @param len  Number of bytes to write (1–8).
+ */
+void write_le(unsigned char* dst, unsigned long long v, int len);
+
+/**
+ * @brief Convert a time value to SQL Server TIME(7) ticks.
+ *
+ * Computes the number of 100-nanosecond ticks since midnight,
+ * where 1 microsecond equals 10 ticks.
+ *
+ * @param hh     Hours (0–23).
+ * @param mm     Minutes (0–59).
+ * @param ss     Seconds (0–59).
+ * @param micro  Microseconds (0–999999).
+ * @return Time in 10⁻⁷-second ticks since midnight.
+ */
+unsigned long long time_to_ticks7(int hh, int mm, int ss, int micro);
+
+/**
+ * @brief Compute days since 0001-01-01 (proleptic Gregorian).
+ *
+ * Converts a civil date (y, m, d) to a day count where 0001-01-01 == 0.
+ * Implementation is based on Howard Hinnant’s days-from-civil algorithm.
+ *
+ * @param y Year (e.g., 2025). Proleptic Gregorian; no BCE/0-year handling.
+ * @param m Month in [1, 12].
+ * @param d Day in [1, 31] (no range validation performed).
+ * @return unsigned int Days since 0001-01-01 (0 for 0001-01-01).
+ *
+ * @note Inputs are assumed valid; behavior is undefined for invalid dates.
+ */
+unsigned int days_since_0001_01_01(int y, int m, int d);

--- a/src/connection.h
+++ b/src/connection.h
@@ -12,6 +12,8 @@
 #ifndef CONNECTION_H
 #define CONNECTION_H
 
+struct BcpProcs;
+
 struct Cursor;
 
 extern PyTypeObject ConnectionType;
@@ -31,6 +33,11 @@ struct Connection
     // The ODBC version the driver supports, from SQLGetInfo(DRIVER_ODBC_VER).  This is set after connecting.
     char odbc_major;
     char odbc_minor;
+
+    // BCP support, loaded on demand.
+    // If bcp.loaded is false, BCP is not supported.
+    // If bcp.loaded is true, all function pointers are valid.
+    BcpProcs* bcp;
 
     // The escape character from SQLGetInfo.  This is not initialized until requested, so this may be zero!
     PyObject* searchescape;

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -91,6 +91,12 @@ struct Cursor
     // Set to SQL_NULL_HANDLE when the cursor is closed.
     HSTMT hstmt;
 
+    // If true, fast executemany will default to using BCP if available.
+    bool use_bcp_fast = false;
+    
+    // BCP configuration
+    long bcp_batch_rows = 0;            // amount of rows per batch, 0 means driver default (no batching)
+
     //
     // SQL Parameters
     //

--- a/src/params.h
+++ b/src/params.h
@@ -8,6 +8,8 @@ struct Cursor;
 
 bool PrepareAndBind(Cursor* cur, PyObject* pSql, PyObject* params, bool skip_first);
 bool ExecuteMulti(Cursor* cur, PyObject* pSql, PyObject* paramArrayObj);
+bool ExecuteMulti_BCP(Cursor* cur, PyObject* pSql, PyObject* param_seq);
+bool ExecuteMulti_BCP_Rowwise(Cursor* cur, PyObject* pSql, PyObject* param_seq);
 bool GetParameterInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInfo& info, bool isTVP);
 void FreeParameterData(Cursor* cur);
 void FreeParameterInfo(Cursor* cur);

--- a/tests/sqlalchemy_big_batch_extended.py
+++ b/tests/sqlalchemy_big_batch_extended.py
@@ -1,0 +1,277 @@
+# benchmark_bcp.py
+import time
+import random
+import string
+import datetime as dt
+from contextlib import contextmanager
+from decimal import Decimal
+
+import sqlalchemy as sa
+from sqlalchemy import (
+    Table, Column, Integer, BigInteger, String, Float,
+    Boolean, Time, MetaData, insert, event
+)
+# SQL Server-specific types for precise mapping
+from sqlalchemy.dialects.mssql import DATETIME2, DATETIMEOFFSET
+
+SQL_COPT_SS_BCP = 1219
+SQL_BCP_ON = 1
+
+# ---------- CONFIG ----------
+# Adjust connection string as needed
+CONN_URL = (
+    "mssql+pyodbc://sa:YourStrong!Passw0rd@localhost,1433/BcpTest"
+    "?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=no"
+)
+TOTAL_ROWS   = 50_000
+CHUNK_ROWS   = 10_000
+BCP_BATCH    = 10_000
+NAME_LEN     = 20
+# ----------------------------
+
+md = MetaData()
+t = Table(
+    "BcpTest_extend", md,
+    Column("id", Integer, nullable=False),           # SQLINT4
+    Column("id_big", BigInteger, nullable=False),    # SQL_BIGINT
+    Column("is_active", Boolean, nullable=False),    # BIT
+    Column("name", String(50)),                      # VARCHAR
+    Column("val", Float),                            # FLOAT(53)
+    Column("t", Time, nullable=True),                # TIME (Python datetime.time)
+    Column("d_str", String(10)),                     # DATE as string
+    Column("dt_str", String(32)),                    # DATETIME as string
+    Column("amount_dec_18_4", sa.DECIMAL(18, 4)),    # DECIMAL(18,4)
+    Column("amount_num_38_0", sa.NUMERIC(38, 0)),    # NUMERIC(38,0)
+    Column("d_native", sa.DATE),                     # SQL Server DATE
+    Column("dt2_native", DATETIME2(precision=7)),    # SQL Server DATETIME2(7)
+    Column("dto_native", DATETIMEOFFSET(precision=7)),  # SQL Server DATETIMEOFFSET(7)
+    schema="dbo",
+)
+
+def make_engine(use_sa_fast_executemany: bool):
+    return sa.create_engine(
+        CONN_URL,
+        connect_args={"attrs_before": {SQL_COPT_SS_BCP: SQL_BCP_ON}},
+        fast_executemany=use_sa_fast_executemany,
+        pool_pre_ping=True,
+    )
+
+def set_bcp_event(engine, enable_bcp: bool, bcp_batch_rows: int):
+    @event.listens_for(engine, "before_cursor_execute")
+    def _apply_bcp_options(conn, cursor, statement, parameters, context, executemany):
+        if not executemany:
+            return
+        try:
+            cursor.use_bcp_fast = bool(enable_bcp)
+            if enable_bcp:
+                cursor.bcp_batch_rows = int(bcp_batch_rows)
+        except AttributeError:
+            pass
+
+@contextmanager
+def timer(label):
+    t0 = time.perf_counter()
+    yield lambda: time.perf_counter() - t0
+    dt_elapsed = time.perf_counter() - t0
+    print(f"{label}: {dt_elapsed:.3f}s")
+
+def rand_name(n=NAME_LEN):
+    alph = string.ascii_letters
+    return "".join(random.choice(alph) for _ in range(n))
+
+def rand_time():
+    # Random time with microseconds
+    return dt.time(
+        hour=random.randint(0, 23),
+        minute=random.randint(0, 59),
+        second=random.randint(0, 59),
+        microsecond=random.randint(0, 999999),
+    )
+
+def rand_date_str():
+    # 'YYYY-MM-DD'
+    start = dt.date(2000, 1, 1)
+    end   = dt.date(2030, 12, 31)
+    days = (end - start).days
+    d = start + dt.timedelta(days=random.randint(0, days))
+    return d.isoformat()
+
+def rand_datetime_str():
+    # 'YYYY-MM-DD HH:MM:SS.ffffff'
+    start = dt.datetime(2000, 1, 1)
+    end   = dt.datetime(2030, 12, 31, 23, 59, 59, 999999)
+    delta = end - start
+    us_total = random.randrange(delta.days * 24 * 3600 * 1_000_000 + delta.seconds * 1_000_000 + delta.microseconds)
+    d = start + dt.timedelta(microseconds=us_total)
+    return d.isoformat(sep=" ")
+
+# NEW: native generators
+def rand_date():
+    # Python datetime.date in a broad range SQL Server DATE supports (0001-01-01..9999-12-31)
+    # Keep it reasonable for tests:
+    start = dt.date(2000, 1, 1)
+    end   = dt.date(2030, 12, 31)
+    days = (end - start).days
+    return start + dt.timedelta(days=random.randint(0, days))
+
+def rand_datetime2():
+    # Naive datetime (no tzinfo), full microseconds; SQL Server DATETIME2(7) stores 100ns
+    start = dt.datetime(2000, 1, 1)
+    end   = dt.datetime(2030, 12, 31, 23, 59, 59, 999999)
+    delta = end - start
+    us_total = random.randrange(delta.days * 24 * 3600 * 1_000_000 + delta.seconds * 1_000_000 + delta.microseconds)
+    return start + dt.timedelta(microseconds=us_total)
+
+def rand_datetimeoffset():
+    # tz-aware datetime with minute-aligned UTC offset within SQL Server’s +/-14:00 bounds
+    base = rand_datetime2()
+    # choose offsets like -12:00 .. +14:00, minute aligned (often 15/30/45 blocks)
+    hour = random.randint(-12, 14)
+    minute = random.choice([0, 15, 30, 45])
+    # clamp boundary cases to keep within [-14:00, +14:00] safely
+    if hour == -12 and random.random() < 0.2:
+        minute = 0
+    if hour == 14:
+        minute = 0
+    sign = -1 if hour < 0 else 1
+    tz = dt.timezone(dt.timedelta(hours=hour, minutes=sign*minute))
+    return base.replace(tzinfo=tz)
+
+# Fast, safe Decimal generators (stay comfortably within column precision)
+def rand_decimal(precision: int, scale: int, max_int_digits: int = 12) -> Decimal:
+    int_digits = max(1, min(precision - scale, max_int_digits))
+    int_part = random.randint(0, 10**int_digits - 1)
+    sign = -1 if random.random() < 0.2 else 1
+    if scale > 0:
+        frac_digits = min(scale, 6)  # keep generator fast
+        frac_part = random.randint(0, 10**frac_digits - 1)
+        val = Decimal(sign) * (Decimal(int_part) + (Decimal(frac_part) / (Decimal(10) ** frac_digits)))
+        q = Decimal(1) / (Decimal(10) ** scale)   # quantize to exact scale
+        return val.quantize(q)
+    else:
+        return Decimal(sign) * Decimal(int_part)
+
+def rows_generator(start_id: int, count: int):
+    big_base = 9_000_000_000  # ensure > 32-bit range sometimes
+    for i in range(start_id, start_id + count):
+        yield {
+            "id": i,
+            "id_big": big_base + i,
+            "is_active": bool(i & 1),
+            "name": rand_name(),
+            "val": (random.random() * 100.0),
+            "t": rand_time(),
+            "d_str": rand_date_str(),
+            "dt_str": rand_datetime_str(),
+            "amount_dec_18_4": rand_decimal(18, 4),
+            "amount_num_38_0": rand_decimal(38, 0),
+            "d_native":   rand_date(),          # DATE
+            "dt2_native": rand_datetime2(),     # DATETIME2(7)
+            "dto_native": rand_datetimeoffset() # DATETIMEOFFSET(7)
+        }
+
+def ensure_table(engine):
+    with engine.begin() as conn:
+        conn.exec_driver_sql("""
+            IF OBJECT_ID('dbo.BcpTest_extend', 'U') IS NOT NULL
+                DROP TABLE dbo.BcpTest_extend;
+        """)
+        md.create_all(conn)
+        # Optional (benchmarking):
+        # conn.exec_driver_sql("ALTER DATABASE BcpTest SET RECOVERY SIMPLE;")
+        # conn.exec_driver_sql("ALTER DATABASE BcpTest MODIFY FILE (NAME = BcpTest_log, SIZE = 1024MB, FILEGROWTH = 256MB);")
+
+def bulk_insert(engine, use_bcp: bool, total_rows: int, chunk_rows: int):
+    total_inserted = 0
+    total_time = 0.0
+
+    with timer(f"TOTAL {'BCP' if use_bcp else 'NORMAL'}"):
+        if use_bcp:
+            with engine.connect() as conn:
+                conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+                ins = insert(t)
+
+                remaining = total_rows
+                next_id = 1
+                while remaining > 0:
+                    n = min(remaining, chunk_rows)
+                    chunk = list(rows_generator(next_id, n))
+
+                    t0 = time.perf_counter()
+                    r = conn.execute(ins, chunk)
+                    dt_chunk = time.perf_counter() - t0
+
+                    total_time += dt_chunk
+                    rc = getattr(r, "rowcount", -1)
+                    total_inserted += rc if (rc is not None and rc >= 0) else n
+
+                    done = total_rows - (remaining - n)
+                    rate = n / dt_chunk if dt_chunk > 0 else float("inf")
+                    print(f"Chunk {done:>9}/{total_rows} rows in {dt_chunk:.3f}s  ({rate:,.0f} rows/s)")
+
+                    next_id += n
+                    remaining -= n
+        else:
+            with engine.begin() as conn:
+                ins = insert(t)
+
+                remaining = total_rows
+                next_id = 1
+                while remaining > 0:
+                    n = min(remaining, chunk_rows)
+                    chunk = list(rows_generator(next_id, n))
+
+                    t0 = time.perf_counter()
+                    r = conn.execute(ins, chunk)
+                    dt_chunk = time.perf_counter() - t0
+
+                    total_time += dt_chunk
+                    rc = getattr(r, "rowcount", -1)
+                    total_inserted += rc if (rc is not None and rc >= 0) else n
+
+                    done = total_rows - (remaining - n)
+                    rate = n / dt_chunk if dt_chunk > 0 else float("inf")
+                    print(f"Chunk {done:>9}/{total_rows} rows in {dt_chunk:.3f}s  ({rate:,.0f} rows/s)")
+
+                    next_id += n
+                    remaining -= n
+
+    rows_per_s = total_rows / total_time if total_time > 0 else float("inf")
+    print(
+        f"\nSummary [{'BCP' if use_bcp else 'NORMAL'}]: "
+        f"{total_rows:,} rows in {total_time:.3f}s  →  {rows_per_s:,.0f} rows/s  "
+        f"(reported inserted: {total_inserted:,})\n"
+    )
+
+def verify_count(engine, expected: int):
+    with engine.begin() as conn:
+        c = conn.exec_driver_sql("SELECT COUNT(*) FROM dbo.BcpTest_extend;").scalar()
+        print(f"Verify table count: {c:,} (expected {expected:,})")
+        return c
+
+def main():
+    # NORMAL
+    eng_normal = make_engine(use_sa_fast_executemany=False)
+    ensure_table(eng_normal)
+    bulk_insert(eng_normal, use_bcp=False, total_rows=TOTAL_ROWS, chunk_rows=CHUNK_ROWS)
+    verify_count(eng_normal, TOTAL_ROWS)
+
+    # reset
+    with eng_normal.begin() as conn:
+        conn.exec_driver_sql("TRUNCATE TABLE dbo.BcpTest_extend;")
+
+    # BCP fast path
+    eng_bcp = sa.create_engine(
+        CONN_URL,
+        connect_args={"attrs_before": {SQL_COPT_SS_BCP: SQL_BCP_ON}},
+        fast_executemany=True,
+        isolation_level="AUTOCOMMIT",
+        pool_pre_ping=True,
+    )
+    set_bcp_event(eng_bcp, enable_bcp=True, bcp_batch_rows=BCP_BATCH)
+    ensure_table(eng_bcp)
+    bulk_insert(eng_bcp, use_bcp=True, total_rows=TOTAL_ROWS, chunk_rows=CHUNK_ROWS)
+    verify_count(eng_bcp, TOTAL_ROWS)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Dependency free BCP support for fast executemany path, also includes standalone connection BCP part.

Triggers if the use_bcp_fast flag is set in the cursor struct. If BCP is not supported (drivers not installed) it will default to regular fast executemany path.

#Note: Support for SLQDATE and SQLDATETIME types is not optimal, they are handled as SQLCHARACTER and passed like that to the BCP server which then handles the conversion. It is more robust and stable, but slower than a native solution. Additional effort would be required to further increase speed of execution (judging by the benchmark results this is plenty fast, but there is still space for improvement).  

Included is also the test used for benchmarking.

<img width="617" height="349" alt="image" src="https://github.com/user-attachments/assets/d20dd595-5857-4a0e-90e2-be5fce2f687e" />

